### PR TITLE
Link dl library (Linux/macOS)

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -5,10 +5,11 @@ package webview
 #cgo CXXFLAGS: -I${SRCDIR}/libs/webview/include -DWEBVIEW_STATIC
 
 #cgo linux openbsd freebsd netbsd CXXFLAGS: -DWEBVIEW_GTK -std=c++11
+#cgo linux openbsd freebsd netbsd LDFLAGS: -ldl
 #cgo linux openbsd freebsd netbsd pkg-config: gtk+-3.0 webkit2gtk-4.0
 
 #cgo darwin CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
-#cgo darwin LDFLAGS: -framework WebKit
+#cgo darwin LDFLAGS: -framework WebKit -ldl
 
 #cgo windows CXXFLAGS: -DWEBVIEW_EDGE -std=c++14 -I${SRCDIR}/libs/mswebview2/include
 #cgo windows LDFLAGS: -static -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion


### PR DESCRIPTION
Fixes a possible error about undefined reference to symbol "dlclose".

Error observed with Ubuntu 20.04.6, GCC 9.4.0.