### PR TITLE
show or hide title bar. hide title bar,bind `StartDragging` function to Drag window.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDEA
+.idea

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -3368,7 +3368,7 @@ public:
   }
 
   void set_minimize_impl() override {
-    PostMessage(m_window, WM_SYSCOMMAND, SW_MINIMIZE, 0);
+    PostMessage(m_window, WM_SYSCOMMAND, SC_MINIMIZE, 0);
   }
 
   void set_size_impl(int width, int height, webview_hint_t hints) override {

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -3360,18 +3360,18 @@ public:
   }
 
   void set_maximize_impl() override {
-    ShowWindow(m_widget, SW_MAXIMIZE);
-    UpdateWindow(m_widget);
+    ShowWindow(m_window, SW_MAXIMIZE);
+    UpdateWindow(m_window);
   }
 
   void set_un_maximize_impl() override {
-    ShowWindow(m_widget, SW_RESTORE);
-    UpdateWindow(m_widget);
+    ShowWindow(m_window, SW_RESTORE);
+    UpdateWindow(m_window);
   }
 
   void set_minimize_impl() override {
-    ShowWindow(m_widget, SW_MINIMIZE);
-    UpdateWindow(m_widget);
+    ShowWindow(m_window, SW_MINIMIZE);
+    UpdateWindow(m_window);
   }
 
   void set_size_impl(int width, int height, webview_hint_t hints) override {

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -3360,18 +3360,15 @@ public:
   }
 
   void set_maximize_impl() override {
-    ShowWindow(m_window, SW_MAXIMIZE);
-    UpdateWindow(m_window);
+    PostMessage(m_window, WM_SYSCOMMAND, SC_MAXIMIZE, 0);
   }
 
   void set_un_maximize_impl() override {
-    ShowWindow(m_window, SW_RESTORE);
-    UpdateWindow(m_window);
+    PostMessage(mainWindow, WM_SYSCOMMAND, SC_RESTORE, 0);
   }
 
   void set_minimize_impl() override {
-    ShowWindow(m_window, SW_MINIMIZE);
-    UpdateWindow(m_window);
+    PostMessage(mainWindow, WM_SYSCOMMAND, SW_MINIMIZE, 0);
   }
 
   void set_size_impl(int width, int height, webview_hint_t hints) override {

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -263,6 +263,27 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_title_bar(webview_t w, int b);
 
 /**
+ * Set the native window maximize.
+ *
+ * @param w The webview instance.
+ */
+WEBVIEW_API void webview_set_maximize(webview_t w);
+
+/**
+ * Set the native window un maximize.
+ *
+ * @param w The webview instance.
+ */
+WEBVIEW_API void webview_set_un_maximize(webview_t w);
+
+/**
+ * Set the native window minimize.
+ *
+ * @param w The webview instance.
+ */
+WEBVIEW_API void webview_set_minimize(webview_t w);
+
+/**
  * Updates the size of the native window.
  *
  * @param w The webview instance.
@@ -1024,6 +1045,9 @@ if (status === 0) {\
   void dispatch(std::function<void()> f) { dispatch_impl(f); }
   void set_title(const std::string &title) { set_title_impl(title); }
   void set_title_bar(int b) { set_title_bar_impl(b); }
+  void set_maximize() { set_maximize_impl(); }
+  void set_un_maximize() { set_un_maximize_impl(); }
+  void set_minimize() { set_minimize_impl(); }
 
   void set_size(int width, int height, webview_hint_t hints) {
     set_size_impl(width, height, hints);
@@ -1051,6 +1075,9 @@ protected:
   virtual void dispatch_impl(std::function<void()> f) = 0;
   virtual void set_title_impl(const std::string &title) = 0;
   virtual void set_title_bar_impl(int b) = 0;
+  virtual void set_maximize_impl() = 0;
+  virtual void set_un_maximize_impl() = 0;
+  virtual void set_minimize_impl() = 0;
   virtual void set_size_impl(int width, int height, webview_hint_t hints) = 0;
   virtual void start_dragging_impl() = 0;
   virtual void set_always_on_top_impl(int b) = 0;
@@ -1370,6 +1397,12 @@ public:
   }
 
   void set_title_bar_impl(int b) override {}
+
+  void set_maximize_impl() override {}
+
+  void set_un_maximize_impl() override {}
+
+  void set_minimize_impl() override {}
 
   void set_size_impl(int width, int height, webview_hint_t hints) override {
     gtk_window_set_resizable(GTK_WINDOW(m_window), hints != WEBVIEW_HINT_FIXED);
@@ -1696,6 +1729,12 @@ public:
   }
 
   void set_title_bar_impl(int b) override {}
+
+  void set_maximize_impl() override {}
+
+  void set_un_maximize_impl() override {}
+
+  void set_minimize_impl() override {}
 
   void set_size_impl(int width, int height, webview_hint_t hints) override {
     objc::autoreleasepool arp;
@@ -3320,6 +3359,21 @@ public:
         SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
   }
 
+  void set_maximize_impl() override {
+    ShowWindow(m_widget, SW_MAXIMIZE);
+    UpdateWindow(m_widget);
+  }
+
+  void set_un_maximize_impl() override {
+    ShowWindow(m_widget, SW_RESTORE);
+    UpdateWindow(m_widget);
+  }
+
+  void set_minimize_impl() override {
+    ShowWindow(m_widget, SW_MINIMIZE);
+    UpdateWindow(m_widget);
+  }
+
   void set_size_impl(int width, int height, webview_hint_t hints) override {
     auto style = GetWindowLong(m_window, GWL_STYLE);
     if (hints == WEBVIEW_HINT_FIXED) {
@@ -3617,6 +3671,18 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title) {
 
 WEBVIEW_API void webview_set_title_bar(webview_t w, int b) {
   static_cast<webview::webview *>(w)->set_title_bar(b);
+}
+
+WEBVIEW_API void webview_set_maximize(webview_t w) {
+  static_cast<webview::webview *>(w)->set_maximize();
+}
+
+WEBVIEW_API void webview_set_un_maximize(webview_t w) {
+  static_cast<webview::webview *>(w)->set_un_maximize();
+}
+
+WEBVIEW_API void webview_set_minimize(webview_t w) {
+  static_cast<webview::webview *>(w)->set_minimize();
 }
 
 WEBVIEW_API void webview_set_size(webview_t w, int width, int height,

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -285,7 +285,7 @@ WEBVIEW_API void webview_start_dragging(webview_t w);
  *
  * @param w The webview instance.
  */
-WEBVIEW_API void webview_set_always_on_top(webview_t w);
+WEBVIEW_API void webview_set_always_on_top(webview_t w,int b);
 
 /**
  * Navigates webview to the given URL. URL may be a properly encoded data URI.
@@ -1033,8 +1033,8 @@ if (status === 0) {\
     start_dragging_impl();
   }
 
-  void set_always_on_top() {
-    set_always_on_top_impl();
+  void set_always_on_top(int b) {
+    set_always_on_top_impl(b);
   }
 
   void set_html(const std::string &html) { set_html_impl(html); }
@@ -1053,7 +1053,7 @@ protected:
   virtual void set_title_bar_impl(int b) = 0;
   virtual void set_size_impl(int width, int height, webview_hint_t hints) = 0;
   virtual void start_dragging_impl() = 0;
-  virtual void set_always_on_top_impl() = 0;
+  virtual void set_always_on_top_impl(int b) = 0;
   virtual void set_html_impl(const std::string &html) = 0;
   virtual void init_impl(const std::string &js) = 0;
   virtual void eval_impl(const std::string &js) = 0;
@@ -1389,7 +1389,7 @@ public:
   }
   void start_dragging_impl() override {}
 
-  void set_always_on_top_impl() override {}
+  void set_always_on_top_impl(int b) override {}
 
   void navigate_impl(const std::string &url) override {
     webkit_web_view_load_uri(WEBKIT_WEB_VIEW(m_webview), url.c_str());
@@ -1722,7 +1722,7 @@ public:
     objc::msg_send<void>(m_window, "center"_sel);
   }
   void start_dragging_impl() override {}
-  void set_always_on_top_impl() override {}
+  void set_always_on_top_impl(int b) override {}
   void navigate_impl(const std::string &url) override {
     objc::autoreleasepool arp;
 
@@ -3354,8 +3354,8 @@ public:
     SendMessage(m_window, WM_SYSCOMMAND, SC_MOVE| HTCAPTION, 0);
   }
 
-  void set_always_on_top_impl() override {
-    SetWindowPos(m_window, HWND_TOPMOST,0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+  void set_always_on_top_impl(int b) override {
+    SetWindowPos(m_window, b == 0 ? HWND_NOTOPMOST : HWND_TOPMOST,0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
   }
 
   void navigate_impl(const std::string &url) override {
@@ -3628,8 +3628,8 @@ WEBVIEW_API void webview_start_dragging(webview_t w) {
   static_cast<webview::webview *>(w)->start_dragging();
 }
 
-WEBVIEW_API void webview_set_always_on_top(webview_t w) {
-  static_cast<webview::webview *>(w)->set_always_on_top();
+WEBVIEW_API void webview_set_always_on_top(webview_t w, int b) {
+  static_cast<webview::webview *>(w)->set_always_on_top(b);
 }
 
 WEBVIEW_API void webview_navigate(webview_t w, const char *url) {

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -281,6 +281,13 @@ WEBVIEW_API void webview_set_size(webview_t w, int width, int height,
 WEBVIEW_API void webview_start_dragging(webview_t w);
 
 /**
+ * Set Always On Top of the native window.
+ *
+ * @param w The webview instance.
+ */
+WEBVIEW_API void webview_set_always_on_top(webview_t w);
+
+/**
  * Navigates webview to the given URL. URL may be a properly encoded data URI.
  *
  * Example:
@@ -1026,6 +1033,10 @@ if (status === 0) {\
     start_dragging_impl();
   }
 
+  void set_always_on_top() {
+    set_always_on_top_impl();
+  }
+
   void set_html(const std::string &html) { set_html_impl(html); }
   void init(const std::string &js) { init_impl(js); }
   void eval(const std::string &js) { eval_impl(js); }
@@ -1042,6 +1053,7 @@ protected:
   virtual void set_title_bar_impl(int b) = 0;
   virtual void set_size_impl(int width, int height, webview_hint_t hints) = 0;
   virtual void start_dragging_impl() = 0;
+  virtual void set_always_on_top_impl() = 0;
   virtual void set_html_impl(const std::string &html) = 0;
   virtual void init_impl(const std::string &js) = 0;
   virtual void eval_impl(const std::string &js) = 0;
@@ -1377,6 +1389,8 @@ public:
   }
   void start_dragging_impl() override {}
 
+  void set_always_on_top_impl() override {}
+
   void navigate_impl(const std::string &url) override {
     webkit_web_view_load_uri(WEBKIT_WEB_VIEW(m_webview), url.c_str());
   }
@@ -1708,6 +1722,7 @@ public:
     objc::msg_send<void>(m_window, "center"_sel);
   }
   void start_dragging_impl() override {}
+  void set_always_on_top_impl() override {}
   void navigate_impl(const std::string &url) override {
     objc::autoreleasepool arp;
 
@@ -3339,6 +3354,10 @@ public:
     SendMessage(m_window, WM_SYSCOMMAND, SC_MOVE| HTCAPTION, 0);
   }
 
+  void set_always_on_top_impl() override {
+    SetWindowPos(m_window, HWND_TOPMOST,0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+  }
+
   void navigate_impl(const std::string &url) override {
     auto wurl = widen_string(url);
     m_webview->Navigate(wurl.c_str());
@@ -3607,6 +3626,10 @@ WEBVIEW_API void webview_set_size(webview_t w, int width, int height,
 
 WEBVIEW_API void webview_start_dragging(webview_t w) {
   static_cast<webview::webview *>(w)->start_dragging();
+}
+
+WEBVIEW_API void webview_set_always_on_top(webview_t w) {
+  static_cast<webview::webview *>(w)->set_always_on_top();
 }
 
 WEBVIEW_API void webview_navigate(webview_t w, const char *url) {

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -3426,7 +3426,7 @@ public:
 
   void set_resizable_impl(int b) override {
     auto style = GetWindowLong(m_window, GWL_STYLE);
-    if (is_resizable_ == 0) {
+    if (b == 0) {
       style &= ~WS_THICKFRAME;
     } else {
       style |= WS_THICKFRAME;

--- a/libs/webview/include/webview.h
+++ b/libs/webview/include/webview.h
@@ -3364,11 +3364,11 @@ public:
   }
 
   void set_un_maximize_impl() override {
-    PostMessage(mainWindow, WM_SYSCOMMAND, SC_RESTORE, 0);
+    PostMessage(m_window, WM_SYSCOMMAND, SC_RESTORE, 0);
   }
 
   void set_minimize_impl() override {
-    PostMessage(mainWindow, WM_SYSCOMMAND, SW_MINIMIZE, 0);
+    PostMessage(m_window, WM_SYSCOMMAND, SW_MINIMIZE, 0);
   }
 
   void set_size_impl(int width, int height, webview_hint_t hints) override {

--- a/webview.go
+++ b/webview.go
@@ -210,6 +210,10 @@ func (w *webview) StartDragging() {
 	C.webview_start_dragging(w.w)
 }
 
+func (w *webview) SetAlwaysOnTop() {
+	C.webview_set_always_on_top(w.w)
+}
+
 func (w *webview) Init(js string) {
 	s := C.CString(js)
 	defer C.free(unsafe.Pointer(s))

--- a/webview.go
+++ b/webview.go
@@ -95,6 +95,9 @@ type WebView interface {
 	// StartDragging Drag native window.
 	StartDragging()
 
+	// SetAlwaysOnTop set always on top native window.
+	SetAlwaysOnTop()
+
 	// Navigate navigates webview to the given URL. URL may be a properly encoded data.
 	// URI. Examples:
 	// w.Navigate("https://github.com/webview/webview")

--- a/webview.go
+++ b/webview.go
@@ -86,6 +86,9 @@ type WebView interface {
 	// thread.
 	SetTitle(title string)
 
+	// SetTitleBar show or hide title bar
+	SetTitleBar(b bool)
+
 	// SetSize updates native window size. See Hint constants.
 	SetSize(w int, h int, hint Hint)
 
@@ -193,6 +196,10 @@ func (w *webview) SetTitle(title string) {
 	s := C.CString(title)
 	defer C.free(unsafe.Pointer(s))
 	C.webview_set_title(w.w, s)
+}
+
+func (w *webview) SetTitleBar(b bool) {
+	C.webview_set_title_bar(w.w, boolToInt(b))
 }
 
 func (w *webview) SetSize(width int, height int, hint Hint) {

--- a/webview.go
+++ b/webview.go
@@ -25,12 +25,12 @@ void CgoWebViewUnbind(webview_t w, const char *name);
 */
 import "C"
 import (
+	"encoding/json"
+	"errors"
 	_ "github.com/webview/webview_go/libs/mswebview2"
 	_ "github.com/webview/webview_go/libs/mswebview2/include"
 	_ "github.com/webview/webview_go/libs/webview"
 	_ "github.com/webview/webview_go/libs/webview/include"
-	"encoding/json"
-	"errors"
 	"reflect"
 	"runtime"
 	"sync"
@@ -88,6 +88,9 @@ type WebView interface {
 
 	// SetSize updates native window size. See Hint constants.
 	SetSize(w int, h int, hint Hint)
+
+	// StartDragging Drag native window.
+	StartDragging()
 
 	// Navigate navigates webview to the given URL. URL may be a properly encoded data.
 	// URI. Examples:
@@ -194,6 +197,10 @@ func (w *webview) SetTitle(title string) {
 
 func (w *webview) SetSize(width int, height int, hint Hint) {
 	C.webview_set_size(w.w, C.int(width), C.int(height), C.webview_hint_t(hint))
+}
+
+func (w *webview) StartDragging() {
+	C.webview_start_dragging(w.w)
 }
 
 func (w *webview) Init(js string) {

--- a/webview.go
+++ b/webview.go
@@ -89,6 +89,15 @@ type WebView interface {
 	// SetTitleBar show or hide title bar
 	SetTitleBar(b bool)
 
+	// SetMaximize set native window maximize
+	SetMaximize()
+
+	// SetUnMaximize set native window unmaximize
+	SetUnMaximize()
+
+	// SetMinimize set native window minimize
+	SetMinimize()
+
 	// SetSize updates native window size. See Hint constants.
 	SetSize(w int, h int, hint Hint)
 
@@ -203,6 +212,18 @@ func (w *webview) SetTitle(title string) {
 
 func (w *webview) SetTitleBar(b bool) {
 	C.webview_set_title_bar(w.w, boolToInt(b))
+}
+
+func (w *webview) SetMaximize() {
+	C.webview_set_maximize(w.w)
+}
+
+func (w *webview) SetUnMaximize() {
+	C.webview_set_un_maximize(w.w)
+}
+
+func (w *webview) SetMinimize() {
+	C.webview_set_minimize(w.w)
 }
 
 func (w *webview) SetSize(width int, height int, hint Hint) {

--- a/webview.go
+++ b/webview.go
@@ -96,7 +96,7 @@ type WebView interface {
 	StartDragging()
 
 	// SetAlwaysOnTop set always on top native window.
-	SetAlwaysOnTop()
+	SetAlwaysOnTop(b bool)
 
 	// Navigate navigates webview to the given URL. URL may be a properly encoded data.
 	// URI. Examples:
@@ -213,8 +213,8 @@ func (w *webview) StartDragging() {
 	C.webview_start_dragging(w.w)
 }
 
-func (w *webview) SetAlwaysOnTop() {
-	C.webview_set_always_on_top(w.w)
+func (w *webview) SetAlwaysOnTop(b bool) {
+	C.webview_set_always_on_top(w.w, boolToInt(b))
 }
 
 func (w *webview) Init(js string) {

--- a/webview.go
+++ b/webview.go
@@ -107,6 +107,9 @@ type WebView interface {
 	// SetAlwaysOnTop set always on top native window.
 	SetAlwaysOnTop(b bool)
 
+	// SetResizable set resizable native window.
+	SetResizable(b bool)
+
 	// Navigate navigates webview to the given URL. URL may be a properly encoded data.
 	// URI. Examples:
 	// w.Navigate("https://github.com/webview/webview")
@@ -236,6 +239,10 @@ func (w *webview) StartDragging() {
 
 func (w *webview) SetAlwaysOnTop(b bool) {
 	C.webview_set_always_on_top(w.w, boolToInt(b))
+}
+
+func (w *webview) SetResizable(b bool) {
+	C.webview_set_resizable(w.w, boolToInt(b))
 }
 
 func (w *webview) Init(js string) {


### PR DESCRIPTION
### show or hide title bar
example: go:
 `w.SetTitleBar(false)`

### hide title bar,bind `StartDragging` function to Drag window.
example:  
go:
`_ = w.Bind("dragging", w.StartDragging)`

html:
`<div id="my_title_bar" style="width:100%; height:30px; background:red;"> My Dragging Title Bar</div>`

js:
`
   document.addEventListener("DOMContentLoaded", ()=>{
       document.querySelector("#my_title_bar").addEventListener("mousemove", event => window.dragging());
    });
`