### PR TITLE
Update to webkit2gtk-4.1 (4.0 is removed from new releases of linux)

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -6,7 +6,7 @@ package webview
 
 #cgo linux openbsd freebsd netbsd CXXFLAGS: -DWEBVIEW_GTK -std=c++11
 #cgo linux openbsd freebsd netbsd LDFLAGS: -ldl
-#cgo linux openbsd freebsd netbsd pkg-config: gtk+-3.0 webkit2gtk-4.0
+#cgo linux openbsd freebsd netbsd pkg-config: gtk+-3.0 webkit2gtk-4.1
 
 #cgo darwin CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
 #cgo darwin LDFLAGS: -framework WebKit -ldl


### PR DESCRIPTION
Library already supports 4.1, but the go-code requires 4.0 to be installed - but 4.0 is now not available anymore in many new installations of Linux (Ubuntu 24.04)