### PR TITLE
bump version to fix missing library on new systems

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -6,7 +6,7 @@ package webview
 
 #cgo linux openbsd freebsd netbsd CXXFLAGS: -DWEBVIEW_GTK -std=c++11
 #cgo linux openbsd freebsd netbsd LDFLAGS: -ldl
-#cgo linux openbsd freebsd netbsd pkg-config: gtk+-3.0 webkit2gtk-4.0
+#cgo linux openbsd freebsd netbsd pkg-config: gtk+-3.0 webkit2gtk-4.1
 
 #cgo darwin CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
 #cgo darwin LDFLAGS: -framework WebKit -ldl


### PR DESCRIPTION
webkit2gtk4.0 has become unavailable on current builds of major operating systems, bumping the library requirement to webkit2gtk4.1 fixed the issue on Debian bookworm